### PR TITLE
Removing lines that were causing Import Error

### DIFF
--- a/mysite/main/admin.py
+++ b/mysite/main/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Company
+# from .models import Company
 # Register your models here.
 
-admin.site.register(Company)
+# admin.site.register(Company)


### PR DESCRIPTION
These two lines were trying to import a model which did not exist. This crashed the server when booting up. The fix is simple, either just remove these lines or declare the model.